### PR TITLE
add splitter to subset state site info

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,6 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -23,7 +23,8 @@ list(
   # TODO: PULL SITE DATA HERE
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter)),
+    tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
     # Insert step for tallying data here
     tar_target(count, tally(nwis_data)),
     # Insert step for plotting data here


### PR DESCRIPTION
When I added IN and IA to states, the `nwis_inventory_` for each state got rebuilt, but the  `nwis_data_`, `count_`, and `fig_` targets were only built for the new states.